### PR TITLE
Fix number of arguments in imperative mode

### DIFF
--- a/src/operator/tensor/hadamard_op.h
+++ b/src/operator/tensor/hadamard_op.h
@@ -54,23 +54,24 @@ inline bool HadaType(const nnvm::NodeAttrs& attrs,
 }
 
 
-#define MXNET_OPERATOR_REGISTER_HADAMARD(name)                        \
+#define MXNET_OPERATOR_REGISTER_HADAMARD(name)                      \
   NNVM_REGISTER_OP(name)                                            \
   .set_num_inputs(3)                                                \
   .set_num_outputs(1)                                               \
   .set_attr<nnvm::FListInputNames>("FListInputNames",               \
     [](const NodeAttrs& attrs) {                                    \
-      return std::vector<std::string>{"value", "indices", "sign"};                \
-    })          \
-  .set_attr<nnvm::FInplaceOption>("FInplaceOption",     \
-   [](const NodeAttrs& attrs){                          \
-   return std::vector<std::pair<int, int> >{{0, 0}};    \
-   })                                                           \
-  .set_attr<nnvm::FInferShape>("FInferShape", HadaShape<3, 1>)  \
-  .set_attr<nnvm::FInferType>("FInferType", HadaType<3, 1>)     \
-  .add_argument("value", "ndarray-or-symbol", "first input")                    \
-  .add_argument("indices", "ndarray-or-symbol", "second input")     \
-  .add_argument("sign", "ndarray-or-symbol", "third input")
-    }  // namespace op
+      return std::vector<std::string>{"value", "indices", "sign"};  \
+    })                                                              \
+  .set_attr<nnvm::FInferShape>("FInferShape", HadaShape<3, 1>)      \
+  .set_attr<nnvm::FInferType>("FInferType", HadaType<3, 1>)         \
+  .set_attr<nnvm::FInplaceOption>("FInplaceOption",                 \
+   [](const NodeAttrs& attrs){                                      \
+   return std::vector<std::pair<int, int> >{{0, 0}};                \
+   })                                                               \
+  .add_argument("value", "NDArray-or-Symbol", "first input")        \
+  .add_argument("indices", "NDArray-or-Symbol", "second input")     \
+  .add_argument("sign", "NDArray-or-Symbol", "third input")
+
+}  // namespace op
 }  // namespace mxnet
 #endif  // MXNET_OPERATOR_TENSOR_HADAMARD_OP_H_


### PR DESCRIPTION
In imperative mode the correct number of arguments was not being
detected

[13:06:42]
.../mxnet/dmlc-core/include/dmlc/logging.h:304:
[13:06:42] src/c_api/c_api_ndarray.cc:55: Check failed: num_inputs ==
infered_num_inputs (0 vs. 3) Expecting 3 inputs, got 0 in operator
hadamard_dense

Changing ndarray-or-symbol to NDArray-or-Symbol seems to fix the issue.

Also fix alignment of macro continuations